### PR TITLE
Use collection name for filename

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,13 +109,12 @@ module.exports.workspaceActions = [{
         );
 
         if (!outputPath.length) {
-          outputPath = path.join(
-            context.app.getPath('desktop'),
-            `${slugify(models.workspace.name)}-API-Docs`
-          );
+          outputPath = context.app.getPath('desktop');
         } else {
           outputPath = untildify(outputPath);
         }
+
+        let outputFilename = `${slugify(models.workspace.name)}.postman_collection.json`;
 
         await context.store.setItem(outputPathConfigKey, outputPath);
 
@@ -143,7 +142,7 @@ module.exports.workspaceActions = [{
             workspaceIds: workspaceIdsFilterCsv.split(',')
           };
 
-          fs.writeFileSync(path.join(outputPath, 'requests.postman_collection.json'), postmanExport.transformData(data, filters));
+          fs.writeFileSync(path.join(outputPath, outputFilename), postmanExport.transformData(data, filters));
         } catch (_) {
           await context.app.alert(
             'Something went wrong!',


### PR DESCRIPTION
If a path is provided, this helps make the file easier to identify. Otherwise, you might choose to put it in a general folder and not be able to quickly identify the generic name of "requests.postman_collection.json" as the file you just exported.